### PR TITLE
Updated to use the latest JDK when using install java17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,12 @@ parameters:
 jobs:
   quick-integration-tests:
     docker:
-      - image: cimg/base:2021.11
+      - image: cimg/base:2023.09
     steps:
       - vm-install-tools/install-java11
       - run: java --version | grep -q "openjdk 11"
       - vm-install-tools/install-java17
-      - run: java --version | grep -q "java 17.0.1"
+      - run: java --version | grep -q "java 17"
       - vm-install-tools/install-gradle
       - run: gradle --version | grep -q "Gradle 5.0"
       - vm-install-tools/install-docker-compose
@@ -43,14 +43,14 @@ workflows:
           exclude: SC2148
       - orb-tools/publish-dev:
           orb-name: entur/vm-install-tools
-          context: global
+          context: orb-publishing
           requires:
             - orb-tools/lint
             - orb-tools/pack
             - shellcheck/check
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
-          context: global
+          context: orb-publishing
           requires:
             - orb-tools/publish-dev
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
-###################################################
-## GitHub: https://github.com/Entur/vm-tools-orb ##
-###################################################
+###########################################################
+## GitHub: https://github.com/entur/vm-install-tools-orb ##
+###########################################################
 
 
 description: |
@@ -27,12 +27,12 @@ commands:
       - run:
           name: Install java 17
           command: |
-            wget https://download.oracle.com/java/17/archive/jdk-17.0.1_linux-x64_bin.tar.gz -O /tmp/openjdk-17.tar.gz
+            wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz -O /tmp/openjdk-17.tar.gz
             sudo mkdir -p /usr/lib/jvm
             sudo tar xfvz /tmp/openjdk-17.tar.gz --directory /usr/lib/jvm
             rm -f /tmp/openjdk-17.tar.gz
-            sudo sh -c 'for bin in /usr/lib/jvm/jdk-17.0.1/bin/*; do update-alternatives --install /usr/bin/$(basename $bin) $(basename $bin) $bin 100; done'
-            sudo sh -c 'for bin in /usr/lib/jvm/jdk-17.0.1/bin/*; do update-alternatives --set $(basename $bin) $bin; done'
+            sudo sh -c 'for bin in /usr/lib/jvm/*/bin/*; do update-alternatives --install /usr/bin/$(basename $bin) $(basename $bin) $bin 100; done'
+            sudo sh -c 'for bin in /usr/lib/jvm/*/bin/*; do update-alternatives --set $(basename $bin) $bin; done'
   install-gradle:
     description: install gradle
     steps:

--- a/src/scripts/install-java17.sh
+++ b/src/scripts/install-java17.sh
@@ -1,6 +1,6 @@
-wget https://download.oracle.com/java/17/archive/jdk-17.0.1_linux-x64_bin.tar.gz -O /tmp/openjdk-17.tar.gz
+wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz -O /tmp/openjdk-17.tar.gz
 sudo mkdir -p /usr/lib/jvm
 sudo tar xfvz /tmp/openjdk-17.tar.gz --directory /usr/lib/jvm
 rm -f /tmp/openjdk-17.tar.gz
-sudo sh -c 'for bin in /usr/lib/jvm/jdk-17.0.1/bin/*; do update-alternatives --install /usr/bin/$(basename $bin) $(basename $bin) $bin 100; done'
-sudo sh -c 'for bin in /usr/lib/jvm/jdk-17.0.1/bin/*; do update-alternatives --set $(basename $bin) $bin; done'
+sudo sh -c 'for bin in /usr/lib/jvm/*/bin/*; do update-alternatives --install /usr/bin/$(basename $bin) $(basename $bin) $bin 100; done'
+sudo sh -c 'for bin in /usr/lib/jvm/*/bin/*; do update-alternatives --set $(basename $bin) $bin; done'


### PR DESCRIPTION
Ensures that one is always using the up2date version of JDK17

Spun out of https://github.com/projectlombok/lombok/issues/3065 and the need for java version > 17.0.1

- Minor: Fixed repo-url in orb-file