### PR TITLE
Retrieve latest from temurin binaries

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -27,7 +27,17 @@ commands:
       - run:
           name: Install java 17
           command: |
-            wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz -O /tmp/openjdk-17.tar.gz
+            # Get latest release URL and extract the version (e.g., jdk-17.0.13+11)
+            VERSION=$(curl -sL -o /dev/null -w '%{url_effective}' https://github.com/adoptium/temurin17-binaries/releases/latest | grep -oE 'jdk-[^/]+')
+            export VERSION
+            
+            # Format the version (replace '+' with '_')
+            FORMATTED_VERSION=$(echo "$VERSION" | sed 's/jdk-//' | sed 's/+/_/')
+            export FORMATTED_VERSION
+            
+            # Download
+            wget "https://github.com/adoptium/temurin17-binaries/releases/download/$VERSION/OpenJDK17U-jdk_x64_linux_hotspot_${FORMATTED_VERSION}.tar.gz" -O /tmp/openjdk-17.tar.gz
+            
             sudo mkdir -p /usr/lib/jvm
             sudo tar xfvz /tmp/openjdk-17.tar.gz --directory /usr/lib/jvm
             rm -f /tmp/openjdk-17.tar.gz

--- a/src/scripts/install-java17.sh
+++ b/src/scripts/install-java17.sh
@@ -1,4 +1,14 @@
-wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz -O /tmp/openjdk-17.tar.gz
+# Get latest release URL and extract the version (e.g., jdk-17.0.13+11)
+VERSION=$(curl -sL -o /dev/null -w '%{url_effective}' https://github.com/adoptium/temurin17-binaries/releases/latest | grep -oE 'jdk-[^/]+')
+export VERSION
+
+# Format the version (replace '+' with '_')
+FORMATTED_VERSION=$(echo "$VERSION" | sed 's/jdk-//' | sed 's/+/_/')
+export FORMATTED_VERSION
+
+# Download
+wget "https://github.com/adoptium/temurin17-binaries/releases/download/$VERSION/OpenJDK17U-jdk_x64_linux_hotspot_${FORMATTED_VERSION}.tar.gz" -O /tmp/openjdk-17.tar.gz
+
 sudo mkdir -p /usr/lib/jvm
 sudo tar xfvz /tmp/openjdk-17.tar.gz --directory /usr/lib/jvm
 rm -f /tmp/openjdk-17.tar.gz


### PR DESCRIPTION
The URL https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz now returns a 404 since the Oracle JDK 17 license changed in October 2024 (https://www.oracle.com/java/technologies/downloads/#java17). Attempted to retrieve the latest version from the Temurin binaries instead. 